### PR TITLE
#8 Use Encoding.UTF8 to deserialize API response

### DIFF
--- a/CSharp/GetTranslationsArrayMethod.cs
+++ b/CSharp/GetTranslationsArrayMethod.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Translator.Samples
             using (WebResponse response = request.GetResponse())
             using (Stream respStream = response.GetResponseStream())
             {
-                StreamReader rdr = new StreamReader(respStream, Encoding.ASCII);
+                StreamReader rdr = new StreamReader(respStream, Encoding.UTF8);
                 string strResponse = rdr.ReadToEnd();
                 XDocument doc = XDocument.Parse(@strResponse);
                 XNamespace ns = "http://schemas.datacontract.org/2004/07/Microsoft.MT.Web.Service.V2";


### PR DESCRIPTION
Since the API response with XML with utf-8 encoding, the response must be deserialized with the matching encoding (not Encoding.ASCII) to avoid garbling text in most of the world's languages.