### PR TITLE
#8 Use Encoding.UTF8 to deserialize API response

### DIFF
--- a/CSharp/GetTranslationsMethod.cs
+++ b/CSharp/GetTranslationsMethod.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Translator.Samples
             using (WebResponse response = request.GetResponse())
             using (Stream respStream = response.GetResponseStream())
             {
-                StreamReader rdr = new StreamReader(respStream, System.Text.Encoding.ASCII);
+                StreamReader rdr = new StreamReader(respStream, Encoding.UTF8);
                 string strResponse = rdr.ReadToEnd();
 
                 Console.WriteLine("Available translations for source text '{0}' are", text);


### PR DESCRIPTION
The API returns XML in UTF-8 encoding, so to properly deserialize the response and preserve text in most of the world's languages, Encoding.UTF8 must be used.